### PR TITLE
Increase cookie life to 30 days

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -19,7 +19,7 @@ module.exports = (app) => {
                 expiresIn: "60 days"
             });
             res.cookie('whatsPlayingToken', token, {
-                maxAge: 900000,
+                maxAge: 2592000000, // 30 days in ms
                 httpOnly: true
             });
             console.log("Create User:", user._id);
@@ -71,7 +71,7 @@ module.exports = (app) => {
                 );
 
                 res.cookie('whatsPlayingToken', token, {
-                    maxAge: 900000,
+                    maxAge: 2592000000, // 30 days in ms
                     httpOnly: true
                 });
                 console.log("User signed in:", user._id);
@@ -143,7 +143,7 @@ module.exports = (app) => {
                         expiresIn: "60 days"
                     });
                     res.cookie('whatsPlayingToken', token, {
-                        maxAge: 900000,
+                        maxAge: 2592000000, // 30 days in ms
                         httpOnly: true
                     });
                     res.redirect('/');


### PR DESCRIPTION
Resolves #9 

Cookie life is increased to 30 days (from 15 minutes).